### PR TITLE
Move all SDK core to separate thread

### DIFF
--- a/Source/Database.swift
+++ b/Source/Database.swift
@@ -32,8 +32,6 @@ enum SQLiteError: Error {
     case bind(message: String)
 }
 
-private let databaseName = "openlocate.sqlite3"
-
 protocol Database {
     @discardableResult
     func execute(statement: Statement) throws -> Result
@@ -44,7 +42,8 @@ protocol Database {
 
 final class SQLiteDatabase: Database {
     fileprivate enum Constants {
-        static let databaseQueue = "safagraph.sqlite3.queue"
+        static let databaseName = "openlocate.sqlite3"
+        static let databaseQueue = "openlocate.sqlite3.queue"
     }
 
     private let sqliteTransient = unsafeBitCast(-1, to:sqlite3_destructor_type.self)
@@ -74,14 +73,14 @@ extension SQLiteDatabase {
 
             throw SQLiteError.open(message: "Error getting directory")
         }
-        
+
         let url = URL(fileURLWithPath: path).appendingPathComponent(bundleIdentifier, isDirectory: true)
-        
+
         try FileManager.default.createDirectory(at: url,
                                                 withIntermediateDirectories: true,
                                                 attributes: [FileAttributeKey.protectionKey: FileProtectionType.none])
-        
-        return try open(path: url.appendingPathComponent(databaseName, isDirectory: false).path)
+
+        return try open(path: url.appendingPathComponent(Constants.databaseName, isDirectory: false).path)
     }
 
     static func open(path: String) throws -> SQLiteDatabase {

--- a/Source/LocationDataSource.swift
+++ b/Source/LocationDataSource.swift
@@ -41,7 +41,7 @@ protocol LocationDataSourceType {
 
 final class LocationDatabase: LocationDataSourceType {
 
-    private struct Constants {
+    private enum Constants {
         static let tableName = "Location"
         static let columnId = "_id"
         static let columnLocation = "location"
@@ -60,7 +60,7 @@ final class LocationDatabase: LocationDataSourceType {
             .set(args: [location.data])
             .build()
 
-        _ = try database.execute(statement: statement)
+        try database.execute(statement: statement)
     }
 
     func addAll(locations: [OpenLocateLocationType]) {
@@ -118,7 +118,7 @@ final class LocationDatabase: LocationDataSourceType {
             .build()
 
         do {
-            _ = try database.execute(statement: statement)
+            try database.execute(statement: statement)
         } catch let error {
             debugPrint(error.localizedDescription)
         }
@@ -195,7 +195,7 @@ final class LocationDatabase: LocationDataSourceType {
         .build()
 
         do {
-            _ = try database.execute(statement: statement)
+            try database.execute(statement: statement)
         } catch let error {
             debugPrint(error.localizedDescription)
         }

--- a/Source/LocationService.swift
+++ b/Source/LocationService.swift
@@ -56,6 +56,8 @@ final class LocationService: LocationServiceType {
     private var url: String
     private var headers: Headers?
 
+    private let asyncQueue: DispatchQueue = DispatchQueue(label: "openlocate.queue.async")
+
     var backgroundTask: UIBackgroundTaskIdentifier = UIBackgroundTaskInvalid
 
     init(
@@ -82,26 +84,30 @@ final class LocationService: LocationServiceType {
         debugPrint("Location service started for url : \(url)")
 
         locationManager.subscribe { [weak self] locations in
+            self?.asyncQueue.async {
+                guard let strongSelf = self else { return }
 
-            guard let strongSelf = self else { return }
+                let collectingFields = DeviceCollectingFields.configure(with: strongSelf.collectingFieldsConfiguration)
 
-            let openLocateLocations: [OpenLocateLocation] = locations.map {
-                let info = CollectingFields.Builder(configuration: strongSelf.collectingFieldsConfiguration)
-                    .set(location: $0.location)
-                    .set(network: NetworkInfo.currentNetworkInfo())
-                    .set(deviceInfo: DeviceCollectingFields.configure(with: strongSelf.collectingFieldsConfiguration))
-                    .build()
-                return OpenLocateLocation(timestamp: $0.location.timestamp,
-                                          advertisingInfo: strongSelf.advertisingInfo,
-                                          collectingFields: info,
-                                          context: $0.context)
+                let openLocateLocations: [OpenLocateLocation] = locations.map {
+                    let info = CollectingFields.Builder(configuration: strongSelf.collectingFieldsConfiguration)
+                        .set(location: $0.location)
+                        .set(network: NetworkInfo.currentNetworkInfo())
+                        .set(deviceInfo: collectingFields)
+                        .build()
+
+                    return OpenLocateLocation(timestamp: $0.location.timestamp,
+                                              advertisingInfo: strongSelf.advertisingInfo,
+                                              collectingFields: info,
+                                              context: $0.context)
+                }
+
+                strongSelf.locationDataSource.addAll(locations: openLocateLocations)
+
+                debugPrint(strongSelf.locationDataSource.count)
+
+                strongSelf.postAllLocationsIfNeeded()
             }
-
-            strongSelf.locationDataSource.addAll(locations: openLocateLocations)
-
-            debugPrint(strongSelf.locationDataSource.count)
-
-            strongSelf.postAllLocationsIfNeeded()
         }
 
         UserDefaults.standard.set(true, forKey: isStartedKey)
@@ -161,9 +167,11 @@ extension LocationService {
                     self?.endBackgroundTask()
             },
                 failure: { [weak self] _, error in
-                    debugPrint("failure in posting locations!!! Error: \(error)")
-                    self?.locationDataSource.addAll(locations: locations)
-                    self?.endBackgroundTask()
+                    self?.asyncQueue.async {
+                        debugPrint("failure in posting locations!!! Error: \(error)")
+                        self?.locationDataSource.addAll(locations: locations)
+                        self?.endBackgroundTask()
+                    }
             }
             )
         } catch let error {

--- a/Source/LocationService.swift
+++ b/Source/LocationService.swift
@@ -168,10 +168,11 @@ extension LocationService {
             },
                 failure: { [weak self] _, error in
                     self?.asyncQueue.async {
-                        debugPrint("failure in posting locations!!! Error: \(error)")
                         self?.locationDataSource.addAll(locations: locations)
-                        self?.endBackgroundTask()
                     }
+
+                    self?.endBackgroundTask()
+                    debugPrint("failure in posting locations!!! Error: \(error)")
             }
             )
         } catch let error {

--- a/Tests/BaseTestCase.swift
+++ b/Tests/BaseTestCase.swift
@@ -27,7 +27,8 @@ import XCTest
 
 extension SQLiteDatabase {
     static func testDB() throws -> SQLiteDatabase {
-        guard let path = NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true).first else {
+        guard let path = NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory,
+                                                             .userDomainMask, true).first else {
             throw SQLiteError.open(message: "Error getting directory")
         }
 

--- a/Tests/DatabaseTests.swift
+++ b/Tests/DatabaseTests.swift
@@ -43,4 +43,38 @@ class DatabaseTests: BaseTestCase {
             XCTFail(error.localizedDescription)
         }
     }
+
+    func testReadFromBD() {
+        let query = "SELECT COUNT(*) FROM Location"
+
+        let statement = SQLStatement.Builder()
+            .set(query: query)
+            .set(cached: true)
+            .build()
+
+        do {
+            let database = try SQLiteDatabase.testDB()
+            let result = try database.execute(statement: statement)
+            XCTAssertEqual(Int(result.intValue(column: 0)), 0)
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
+
+    func testReadFromBDFailure() {
+        let query = "SELECT COUNT(*) FROM Location1"
+
+        let statement = SQLStatement.Builder()
+            .set(query: query)
+            .set(cached: true)
+            .build()
+
+        do {
+            let database = try SQLiteDatabase.testDB()
+            _ = try database.execute(statement: statement)
+            XCTFail("Cannot be good. No such table in db")
+        } catch {
+            XCTAssertNotNil(error)
+        }
+    }
 }


### PR DESCRIPTION
Wrap db work to separate sync queue
Wrap `location.subscribe { ... }` and `failure { ... }` to separate async queue

fix #43 